### PR TITLE
feat: sign out from B2C implementation on iOS platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,15 @@ Requires React Native >=0.61
      - ex: `msauth.energy.stash.msal.example://auth`
    - Android: `msauth://<PACKAGE>/<BASE64_URL_ENCODED_PACKAGE_SIGNATURE>`
      - ex: `msauth://energy.stash.msal.example/ab%4E1lPIzBP2j9uELdUz%2BcarjgxQ%3D`
-     - Get your package signature from your `*.keystore`, or from the Google Play console if you have automatic app signing turned on. For local debugging you can enter this command to read your `debug.keystore`:  
+     - Get your package signature from your `*.keystore`, or from the Google Play console if you have automatic app signing turned on. For local debugging you can enter this command to read your `debug.keystore`:
        `keytool -list -v -keystore path/to/debug.keystore -alias androiddebugkey -storepass android -keypass android`
-     - Convert the SHA1 signature to base64:  
+     - Convert the SHA1 signature to base64:
        `echo -n "<YOUR_SHA1_SIGNATURE>" | openssl dgst -binary -sha1 | openssl base64`
      - URL-encode the base64 string
 
 ## Android Setup
 
-1. Follow steps **1 through 3** of the [Using MSAL](https://github.com/AzureAD/microsoft-authentication-library-for-android#using-msal) section of the Android MSAL docs.  
+1. Follow steps **1 through 3** of the [Using MSAL](https://github.com/AzureAD/microsoft-authentication-library-for-android#using-msal) section of the Android MSAL docs.
    **IMPORTANT**: For Step 2, you **MUST** create a file in your assets folder (`android/app/src/main/assets`) named `msal_config.json` containing your MSAL configuration. If you don't have an `assets` folder already, you will have to create one
 
 ## iOS Setup
@@ -70,6 +70,13 @@ const result = await msalClient.acquireTokenSilent({
 // Removes all tokens from the cache for the specified account
 // A call to acquireToken will be required for acquiring subsequent access tokens
 await msalClient.removeAccount({
+  authority,
+  accountIdentifier: result.account.identifier,
+});
+
+// Sign out from B2C for the specified account
+// Only available on iOS platform
+await msalClient.signoutWithAccount({
   authority,
   accountIdentifier: result.account.identifier,
 });

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -19,9 +19,9 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - MSAL (1.0.7):
-    - MSAL/app-lib (= 1.0.7)
-  - MSAL/app-lib (1.0.7)
+  - MSAL (1.1.0):
+    - MSAL/app-lib (= 1.1.0)
+  - MSAL/app-lib (1.1.0)
   - RCTRequired (0.61.5)
   - RCTTypeSafety (0.61.5):
     - FBLazyVector (= 0.61.5)
@@ -220,7 +220,7 @@ PODS:
     - React-cxxreact (= 0.61.5)
     - React-jsi (= 0.61.5)
     - ReactCommon/jscallinvoker (= 0.61.5)
-  - reactnativemsal (1.0.0):
+  - reactnativemsal (1.0.3):
     - MSAL
     - React
   - Yoga (1.14.0)
@@ -322,7 +322,7 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: 118d0d177724c2d67f08a59136eb29ef5943ec75
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
-  MSAL: e4c1cbcf59e04073b427ce9fbfc0346b54abb62e
+  MSAL: 917b8c60ac97dcf50ac5ff987f9f971fb665f7c0
   RCTRequired: b153add4da6e7dbc44aebf93f3cf4fcae392ddf1
   RCTTypeSafety: 9aa1b91d7f9310fc6eadc3cf95126ffe818af320
   React: b6a59ef847b2b40bb6e0180a97d0ca716969ac78
@@ -342,9 +342,9 @@ SPEC CHECKSUMS:
   React-RCTText: 9ccc88273e9a3aacff5094d2175a605efa854dbe
   React-RCTVibration: a49a1f42bf8f5acf1c3e297097517c6b3af377ad
   ReactCommon: 198c7c8d3591f975e5431bec1b0b3b581aa1c5dd
-  reactnativemsal: 7bd79779cdd3d26eb958a8c6802171997b9b370e
+  reactnativemsal: d7733e73fc0f00e53e4bcd2f89fc5952e3a166e0
   Yoga: f2a7cd4280bfe2cca5a7aed98ba0eb3d1310f18b
 
 PODFILE CHECKSUM: e9e0fbe3f0c0b1c1384a48afe904daf373dbb2de
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.9.0

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StyleSheet, Text, Button, SafeAreaView, ScrollView } from 'react-native';
+import { StyleSheet, Text, Button, SafeAreaView, ScrollView, Platform } from 'react-native';
 import MSALCLient, { MSALResult } from 'react-native-msal';
 
 // Example config, modify to your needs
@@ -59,12 +59,28 @@ export default function App() {
       }
     }
   };
+  const signoutWithAccount = async () => {
+    if (authResult) {
+      try {
+        await msalClient.signoutWithAccount({
+          authority: msalConfig.sisuAuthority,
+          accountIdentifier: authResult.account.identifier,
+        });
+        setAuthResult(null);
+      } catch (error) {
+        console.warn(error);
+      }
+    }
+  };
 
   return (
     <SafeAreaView style={styles.container}>
       <Button title="Acquire Token (Interactive)" onPress={acquireToken} />
       <Button title="Acquire Token (Silent)" onPress={acquireTokenSilent} disabled={!authResult} />
       <Button title="Remove account" onPress={removeAccount} disabled={!authResult} />
+      {Platform.OS === 'ios' && (
+        <Button title="Sign out with account" onPress={signoutWithAccount} disabled={!authResult} />
+      )}
       <ScrollView>
         <Text>{JSON.stringify(authResult, null, 4)}</Text>
       </ScrollView>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -46,6 +46,10 @@ export interface MSALRemoveAccountParams extends MSALParams {
   accountIdentifier: string;
 }
 
+export interface MSALSignoutWithAccountParams extends MSALParams {
+  accountIdentifier: string;
+}
+
 export default class MSALClient {
   constructor(private clientId: string) {}
 
@@ -97,5 +101,16 @@ export default class MSALClient {
    */
   public removeAccount = (params: MSALRemoveAccountParams): Promise<void> => {
     return RNMSAL.removeAccount({ clientId: this.clientId, ...params });
+  };
+
+  /**
+   * Sign out from B2C for the secified account
+   * @param {MSALSignoutWithAccountParams} params
+   * @return {Promise<void>} A promise which resolves if sign out is successful,
+   * otherwise rejects
+   * @platform android
+   */
+  public signoutWithAccount = (params: MSALSignoutWithAccountParams): Promise<void> => {
+    return RNMSAL.signoutWithAccount({ clientId: this.clientId, ...params });
   };
 }


### PR DESCRIPTION
Implement complete logout handling on iOS platform that redirects the user to the Microsoft identity platform endpoint to sign out the user properly (not just clear the local cache). It uses the latest MSAL library. Unfortunately this functionality is not available in the official native Android Azure Active Directory library yet.