### PR TITLE
Prepend 'v' to tag in order to support version no. on the tags

### DIFF
--- a/reactnativemsal.podspec
+++ b/reactnativemsal.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.authors      = package["author"]
 
   s.platforms    = { :ios => "10.0" }
-  s.source       = { :git => "https://github.com/stashenergy/react-native-msal", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/stashenergy/react-native-msal", :tag => "v#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m}"
 


### PR DESCRIPTION
When running `pod install` on IOS it complained it could not find the specified version '1.0.4'.
Looking at the tags on repository, I noted it was actually named v1.0.4 instead of 1.0.4. This PR remedys that issue