### PR TITLE
fix: resolve to root instead of hardcode flavor

### DIFF
--- a/example/babel.config.js
+++ b/example/babel.config.js
@@ -8,7 +8,7 @@ module.exports = {
       'module-resolver',
       {
         alias: {
-          [pak.name]: path.join(__dirname, '..', pak.module),
+          [pak.name]: path.join(__dirname, '..'),
         },
       },
     ],


### PR DESCRIPTION
As a [follow up from this comment](https://github.com/expo/expo/issues/8396#issuecomment-692104444):

This allows the appropriate bundler, either Metro or Webpack, to resolve the proper main entry. It uses the `package.json` properties Bob provides. I've tested this by running `yarn web` and `yarn android`, both are working fine 😄 

I also tested the library itself in a managed Expo project, and it seems to be loading fine. I didn't test any features, but both Web and Client are loading without errors.

If you want more context, lmk!